### PR TITLE
Add DDA for drawing lines?

### DIFF
--- a/shaders/computeRasterizer.wgsl
+++ b/shaders/computeRasterizer.wgsl
@@ -86,6 +86,36 @@ fn draw_line(v1: vec3<f32>, v2: vec3<f32>) {
   }
 }
 
+fn DDA_round(a: f32) -> u32{
+  return u32(a + 0.5);
+}
+
+fn DDA_draw_line(v1: vec3<f32>, v2: vec3<f32>){
+  let dx = v2.x - v1.x;
+  let dy = v2.y - v1.y;
+
+  var x = v1.x;
+  var y = v1.y;
+
+  var steps = 0;
+
+  if(abs(dx) > abs(dy)){
+    steps = i32(abs(dx));
+  }else{
+    steps = i32(abs(dy));
+  }
+
+  let xIncrement = dx / f32(steps);
+  let yIncrement = dy / f32(steps);
+
+  color_pixel(DDA_round(x), DDA_round(y), 255u, 255u, 255u);
+  for(var k = 0; k < steps; k = k + 1){
+    x += xIncrement;
+    y += yIncrement;
+    color_pixel(DDA_round(x), DDA_round(y), 255u, 255u, 255u);
+  }
+}
+
 fn project(v: Vertex) -> vec3<f32> {
   var screenPos = uniforms.modelViewProjectionMatrix * vec4<f32>(v.x, v.y, v.z, 1.0);
   screenPos.x = (screenPos.x / screenPos.w) * uniforms.screenWidth;

--- a/shaders/computeRasterizer.wgsl
+++ b/shaders/computeRasterizer.wgsl
@@ -86,33 +86,31 @@ fn draw_line(v1: vec3<f32>, v2: vec3<f32>) {
   }
 }
 
-fn DDA_round(a: f32) -> u32{
-  return u32(a + 0.5);
-}
-
 fn DDA_draw_line(v1: vec3<f32>, v2: vec3<f32>){
-  let dx = v2.x - v1.x;
-  let dy = v2.y - v1.y;
+  // color the pixel at the starting point
+  color_pixel(u32(round(v1.x)), u32(round(v1.y)), 255u, 0u, 255u);
 
   var x = v1.x;
   var y = v1.y;
 
-  var steps = 0;
+  // compute increments from start to end
+  let dx = v2.x - v1.x;
+  let dy = v2.y - v1.y;
+  let steps = max(abs(dx), abs(dy));
 
-  if(abs(dx) > abs(dy)){
-    steps = i32(abs(dx));
-  }else{
-    steps = i32(abs(dy));
+  if(steps < 1e-6){
+    return;
   }
 
-  let xIncrement = dx / f32(steps);
-  let yIncrement = dy / f32(steps);
+  // compute pixel-wise increments
+  let xIncrement = dx / steps;
+  let yIncrement = dy / steps;
 
-  color_pixel(DDA_round(x), DDA_round(y), 255u, 255u, 255u);
-  for(var k = 0; k < steps; k = k + 1){
+  // for each step, add a small increment to each coordinate
+  for(var k = 0; k < i32(steps); k = k + 1){
     x += xIncrement;
     y += yIncrement;
-    color_pixel(DDA_round(x), DDA_round(y), 255u, 255u, 255u);
+    color_pixel(u32(round(x)), u32(round(y)), 255u, 0u, 255u);
   }
 }
 
@@ -144,7 +142,9 @@ fn main(@builtin(global_invocation_id) global_id : vec3<u32>) {
     return;
   }
 
-  draw_triangle(v1, v2, v3);
+  DDA_draw_line(v1, v2);
+  DDA_draw_line(v2, v3);
+  DDA_draw_line(v3, v1);
 }
 
 


### PR DESCRIPTION
The original function `draw_line` may create some artifacts during rasterization. I would like to add the DDA algorithm because it's simple and easy to understand.